### PR TITLE
Set ALLOW_HOSTS from the environment variables

### DIFF
--- a/sentry.conf.py
+++ b/sentry.conf.py
@@ -160,3 +160,6 @@ TRELLO_API_SECRET = ''
 # https://confluence.atlassian.com/display/BITBUCKET/OAuth+Consumers
 BITBUCKET_CONSUMER_KEY = ''
 BITBUCKET_CONSUMER_SECRET = ''
+
+# Django ALLOWED_HOSTS
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '').split(',')


### PR DESCRIPTION
Our sentry is behind an `ELB`, but the healthcheck is a TCP one because AWS doesn't allow us to send a custom `Host` header, so the /_health/ endpoint fails with a 400 as it receives the internal IP as a host.

This PR will allow us to set a custom allow hosts, the value of which will be passed from salt as in https://github.com/ministryofjustice/postcodeinfo-deploy/pull/20 
By doing that we can pass both sentry.dsd.io and the internal IP, making a HTTP healthcheck possible on `ELB` level.
