### PR TITLE
Correct deprecation warning regarding registration

### DIFF
--- a/sentry.conf.py
+++ b/sentry.conf.py
@@ -35,7 +35,10 @@ SENTRY_USE_BIG_INTS = True
 # and thus various UI optimizations should be enabled.
 SENTRY_SINGLE_ORGANIZATION = True
 DEBUG = False
-SENTRY_ALLOW_REGISTRATION = False
+
+# Disable anonymous user registration
+SENTRY_FEATURES['auth:register'] = False
+
 
 #########
 # Redis #


### PR DESCRIPTION
I originally thought our sentry was too old to use SENTRY_FEATURES
but it appears not, as now when you login you get a deprecation
notice and instructed to use it.